### PR TITLE
Add CI workflow and documentation scaffolding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "*"]
+  pull_request:
+
+jobs:
+  lint-test-docs:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}-${{ matrix.python-version }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Ruff Lint
+        run: ruff . --select=E,F,I
+      - name: Black Check
+        run: black --check .
+      - name: Pytest with nbmake
+        run: pytest --nbmake -p no:warnings
+      - name: Build Jupyter Book
+        run: jupyter-book build docs
+      - name: Upload Book Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: site
+          path: docs/_build/html
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs: lint-test-docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: site
+          path: site
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: site

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # AI Math & MLOps by Example
 
+![CI](https://github.com/openaisolutions/mlops/actions/workflows/ci.yml/badge.svg)
+
+View the latest documentation [here](https://openaisolutions.github.io/mlops/).
+
 This repository contains educational material for mastering AI mathematics and practical MLOps techniques. The content is organized into modules that combine concise theory with runnable code examples.
 
 The main project files live under `ai-math-mlops-by-example/`.

--- a/ai-math-mlops-by-example/tests/test_svd.py
+++ b/ai-math-mlops-by-example/tests/test_svd.py
@@ -1,5 +1,5 @@
-import sys
 from pathlib import Path
+import sys
 import numpy as np
 
 # Ensure utils package is on path

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,1 @@
+title: AI Math & MLOps by Example

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -1,0 +1,2 @@
+format: jb-book
+root: intro

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,0 +1,3 @@
+# AI Math & MLOps by Example
+
+Welcome to the documentation site. This book hosts runnable notebooks and tutorials.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.ruff]
+extend-exclude = ["*.ipynb", "docs/_build"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+jupyter-book~=1.0
+nbmake~=1.5
+pytest~=8.0
+black~=24.3
+ruff~=0.4
+
+# Project dependencies
+-r ai-math-mlops-by-example/requirements.txt


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for linting, testing and docs
- introduce project requirements with pinned tool versions
- provide minimal Jupyter Book documentation
- configure Ruff and sort imports in tests
- show CI badge and docs link in README

## Testing
- `ruff check . --select=E,F,I`
- `black --check .`
- `pytest -q`
- `jupyter-book build docs`

------
https://chatgpt.com/codex/tasks/task_e_685a74160fd08321a30a80c07e3924a2